### PR TITLE
updated preconditioner to support multiple radii

### DIFF
--- a/CELES_MAIN.m
+++ b/CELES_MAIN.m
@@ -27,17 +27,28 @@ output = celes_output;
 % complex refractive index of particles, n+ik
 particles.refractiveIndex = 2;
 
+radiusfile = load('ms_test/MS_radi_hole_15_um200step_mod1.mat');
+xposfile = load('ms_test/x_pos_pillar_15_um200step_mod1.mat');
+yposfile = load('ms_test/y_pos_pillar_15_um200step_mod1.mat');
+
+radiusraw = radiusfile.MS_radi_hole_sample(:)';
+xposraw = xposfile.x_pos_m(:);
+yposraw = yposfile.y_pos_m(:);
+
 % radii of particles
 % must be an array with same number of columns as the position matrix
 % e.g. particles.radiusArray = ones(1,100)*100;
-particles.radiusArray = rand(1,100)*181;
+
+particles.radiusArray = radiusraw;
 
 % positions of particles (in three-column format: x,y,z)
-positions = zeros(100,3);
-[pos_x, pos_y] = meshgrid(linspace(-18000,18000,10)',linspace(-18000,18000,10));
-positions(:,1) = pos_x(:);
-positions(:,2) = pos_y(:);
-particles.positionArray = positions;
+positions = zeros(length(xposraw),3);
+positions(:,1) = xposraw;
+positions(:,2) = yposraw;
+% [pos_x, pos_y] = meshgrid(linspace(-14000,14000,10)',linspace(-14000,14000,10));
+% positions(:,1) = pos_x(:);
+% positions(:,2) = pos_y(:);
+particles.positionArray = positions*1e9;
 
 % polar angle of incoming beam/wave, in radians (for Gaussian beams, 
 % only 0 and pi are currently possible)
@@ -50,13 +61,13 @@ initialField.azimuthalAngle = 0;
 initialField.polarization = 'TE';
 
 % width of beam waist (use 0 or inf for plane wave)
-initialField.beamWidth = 20000;
+initialField.beamWidth = 0;
 
 % focal point 
 initialField.focalPoint = [0,0,0];
 
 % vacuum wavelength (same unit as particle positions and radius)
-input.wavelength = 1000;
+input.wavelength = 775;
 
 % complex refractive index of surrounding medium
 input.mediumRefractiveIndex = 1;
@@ -82,7 +93,7 @@ numerics.azimuthalAnglesArray = 0:1e-2:2*pi;
 solver.type = 'BiCGStab';   
 
 % relative accuracy (solver stops when achieved)
-solver.tolerance=1e-4;
+solver.tolerance=5e-4;
 
 % maximal number of iterations (solver stops if exceeded)
 solver.maxIter=1000;
@@ -97,12 +108,12 @@ solver.monitor=true;
 % type of preconditioner (currently only 'blockdiagonal' and 'none'
 % possible)
 % Must be 'none' if particles have different radii
-preconditioner.type = 'none';
+preconditioner.type = 'blockdiagonal';
 
 % for blockdiagonal preconditioner: edge size of partitioning cuboids
-preconditioner.partitionEdgeSizes = [1500,1500,1500];
+preconditioner.partitionEdgeSizes = [5000,5000,3000];
 
-[x,z] = meshgrid(-18000:10:18000,-3000:10:5000); y=x-x;
+[x,z] = meshgrid(-5000:50:5000,00000:50:17000); y=x-x;
 % specify the points where to evaluate the electric near field (3-column
 % array x,y,z)
 output.fieldPoints = [x(:),y(:),z(:)];
@@ -139,7 +150,7 @@ simulation=simulation.evaluateFields;
 figure
 plot_field(gca,simulation,'abs E','Scattered field',simulation.input.particles.radiusArray)
 colormap(jet)
-caxis([0,1])
+caxis([0,15])
 
 figure
 plot_spheres(gca,simulation.input.particles.positionArray,simulation.input.particles.radiusArray,'view xy')

--- a/sources/classes/celes_preconditioner.m
+++ b/sources/classes/celes_preconditioner.m
@@ -82,9 +82,11 @@ classdef celes_preconditioner
                     nmax=simul.numerics.nmax;
                     k = simul.input.k_medium;
                     
+                    
                     for jp=1:length(obj.partitioning)
                         spherArr=obj.partitioning{jp};
                         NSi = length(spherArr);
+                        
                         
                         Idcs= [];
                         for n=1:nmax
@@ -109,6 +111,7 @@ classdef celes_preconditioner
                         stTab = sqrt(1-ctTab.^2);
                         phiTab = atan2(y1mny2,x1mnx2);
                         Plm = legendre_normalized_trigon(ctTab,stTab,2*lmax);
+                        radArrayInd = simul.tables.particles.radiusArrayIndex;
                         
                         for p=0:2*lmax
                             sphHank = sph_bessel(3,p,k*dTab);
@@ -123,7 +126,7 @@ classdef celes_preconditioner
                                                     if abs(m1-m2)<=p
                                                         n2=multi2single_index(1,tau2,l2,m2,lmax);
                                                         n2S2Arr=(1:NSi)+(n2-1)*NSi;
-                                                        TWn1n2 = simul.tables.mieCoefficients(n1)*simul.tables.translationTable.ab5(n2,n1,p+1) * Plm{p+1,abs(m1-m2)+1} .* sphHank .* exp(1i*(m2-m1)*phiTab) ;
+                                                        TWn1n2 = simul.tables.mieCoefficients(radArrayInd(spherArr(:)),n1)*simul.tables.translationTable.ab5(n2,n1,p+1) .* Plm{p+1,abs(m1-m2)+1} .* sphHank .* exp(1i*(m2-m1)*phiTab) ;
                                                         s1eqs2=logical(eye(NSi));
                                                         TWn1n2(s1eqs2(:))=0; % jS1=jS2
                                                         M(n1S1Arr,n2S2Arr) = M(n1S1Arr,n2S2Arr) - TWn1n2;


### PR DESCRIPTION
updated the preconditioner to work with different radii using 'blockdiagonal'. For particles of single radii, should default back to previous preconditioner.